### PR TITLE
Add timeout to network requests

### DIFF
--- a/statsig/statsig_network.py
+++ b/statsig/statsig_network.py
@@ -1,6 +1,8 @@
 import time
 import requests
 
+REQUEST_TIMEOUT = 20
+
 class _StatsigNetwork:
 
     __RETRY_CODES = [408, 500, 502, 503, 504, 522, 524, 599]
@@ -18,7 +20,7 @@ class _StatsigNetwork:
             'STATSIG-CLIENT-TIME': str(round(time.time() * 1000)),
         }
         try:
-            response = requests.post(self.__api + endpoint, json=payload, headers=headers)
+            response = requests.post(self.__api + endpoint, json=payload, headers=headers, timeout=REQUEST_TIMEOUT)
             if response.status_code == 200:
                 data = response.json()
                 if data:
@@ -34,7 +36,7 @@ class _StatsigNetwork:
             'STATSIG-CLIENT-TIME': str(round(time.time() * 1000)),
         }
         try:
-            response = requests.post(self.__api + endpoint, json=payload, headers=headers)
+            response = requests.post(self.__api + endpoint, json=payload, headers=headers, timeout=REQUEST_TIMEOUT)
             if response.status_code in self.__RETRY_CODES:
                 return payload
             else:

--- a/statsig/statsig_network.py
+++ b/statsig/statsig_network.py
@@ -7,11 +7,12 @@ class _StatsigNetwork:
 
     __RETRY_CODES = [408, 500, 502, 503, 504, 522, 524, 599]
 
-    def __init__(self, sdkKey, api):
+    def __init__(self, sdkKey, api, timeout=None):
         self.__sdk_key = sdkKey
         if not api.endswith("/"):
             api = api + "/"
         self.__api = api
+        self.__timeout = timeout or REQUEST_TIMEOUT
     
     def post_request(self, endpoint, payload):
         headers = {
@@ -20,7 +21,7 @@ class _StatsigNetwork:
             'STATSIG-CLIENT-TIME': str(round(time.time() * 1000)),
         }
         try:
-            response = requests.post(self.__api + endpoint, json=payload, headers=headers, timeout=REQUEST_TIMEOUT)
+            response = requests.post(self.__api + endpoint, json=payload, headers=headers, timeout=self.__timeout)
             if response.status_code == 200:
                 data = response.json()
                 if data:
@@ -36,7 +37,7 @@ class _StatsigNetwork:
             'STATSIG-CLIENT-TIME': str(round(time.time() * 1000)),
         }
         try:
-            response = requests.post(self.__api + endpoint, json=payload, headers=headers, timeout=REQUEST_TIMEOUT)
+            response = requests.post(self.__api + endpoint, json=payload, headers=headers, timeout=self.__timeout)
             if response.status_code in self.__RETRY_CODES:
                 return payload
             else:

--- a/statsig/statsig_options.py
+++ b/statsig/statsig_options.py
@@ -4,7 +4,7 @@ import typing
 class StatsigOptions:
     """An object of properties for initializing the sdk with additional parameters"""
 
-    def __init__(self, api: str="https://api.statsig.com/v1/", tier: 'typing.Any'=None):
+    def __init__(self, api: str="https://api.statsig.com/v1/", tier: 'typing.Any'=None, timeout: int=None):
         self._environment = None
         if tier is not None:
             if isinstance(tier, str) or isinstance(tier, StatsigEnvironmentTier):
@@ -15,6 +15,7 @@ class StatsigOptions:
         if api is None:
             api = "https://api.statsig.com/v1/"
         self.api = api
+        self.timeout = timeout
     
     def set_environment_parameter(self, key: str, value: str):
         if self._environment is None:

--- a/statsig/statsig_server.py
+++ b/statsig/statsig_server.py
@@ -19,7 +19,7 @@ class StatsigServer:
             "sdkVersion": __version__,
             "sdkType": "py-server"
         }
-        self._network = _StatsigNetwork(sdkKey, options.api)
+        self._network = _StatsigNetwork(sdkKey, options.api, timeout=options.timeout)
         self._logger = _StatsigLogger(self._network, self.__shutdown_event, self.__statsig_metadata)
         self._evaluator = _Evaluator()
         


### PR DESCRIPTION
Network requests should have a timeout in case of an outage. This could happen anywhere between user systems to statsig. This will prevent the network request from taking down app incase it stays long running


Slack thread for context: https://statsigcommunity.slack.com/archives/C01QVL20EDD/p1637613724280900