### PR TITLE
adds value getter to layer

### DIFF
--- a/statsig/layer.py
+++ b/statsig/layer.py
@@ -31,6 +31,13 @@ class Layer:
 
         return default
 
+    def get_value(self):
+        """Returns an object containing all values of the layer"""
+        value = self.__value
+        for key in value:
+            self._log_parameter_exposure(key)
+        return value
+
     def get_typed(self, key, default=None):
         """Returns the value of the layer at the given key
         iff the type matches the type of the provided default.

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -6,12 +6,13 @@ from statsig import Layer
 class TestLayer(unittest.TestCase):
 
     def test_getters(self):
-        layer = Layer._create('my_layer', {
+        layer_value = {
             "str": "string",
             "num": 4,
             "bool": True,
             "arr": [17],
-        }, "default")
+        }
+        layer = Layer._create('my_layer', layer_value, "default")
 
         self.assertEqual(layer.get_name(), "my_layer")
         self.assertEqual(layer.rule_id, "default")
@@ -40,6 +41,8 @@ class TestLayer(unittest.TestCase):
 
         # List types do not differentiate the type of the values in the list
         self.assertEqual(layer.get_typed("arr", ["str_arr"]), [17])
+
+        self.assertEqual(layer.get_value(), layer_value)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Needs test for exposure logging. I was unfortunately unable to run some of the unit tests.
```
(statsig) ➜  statsig-python-sdk git:(layer-get-value) python3 -m unittest tests/test_statsig_e2e.py             
server running on port 1234
 * Serving Flask app 'tests.mockserver' (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
/Users/nick/.venv/statsig/lib/python3.8/site-packages/werkzeug/serving.py:700: ResourceWarning: unclosed <socket.socket fd=5, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('0.0.0.0', 0)>
  self.socket = socket.fromfd(fd, address_family, socket.SOCK_STREAM)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
 * Running on http://127.0.0.1:1234 (Press CTRL+C to quit)
127.0.0.1 - - [27/Apr/2022 15:42:37] "POST /download_config_specs HTTP/1.1" 200 -
127.0.0.1 - - [27/Apr/2022 15:42:37] code 400, message Bad request version ('0}')
127.0.0.1 - - [27/Apr/2022 15:42:37] "None /download_config_specs HTTP/0.9" HTTPStatus.BAD_REQUEST -
127.0.0.1 - - [27/Apr/2022 15:42:37] "POST /get_id_lists HTTP/1.1" 200 -
127.0.0.1 - - [27/Apr/2022 15:42:37] code 400, message Bad request version ('"py-server"}}')
```