### PR TITLE
Make StatsigEnvironmentTier inherit from str

### DIFF
--- a/statsig/statsig_environment_tier.py
+++ b/statsig/statsig_environment_tier.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class StatsigEnvironmentTier(Enum):
+class StatsigEnvironmentTier(str, Enum):
     """
     The environment tier the SDK is running in.
     Used to view data in the Statsig console by tier


### PR DESCRIPTION
That way we don't get typing errors when we use `set_environment_parameter` as it expects a str.