### PR TITLE
Only perform copy when necessary

### DIFF
--- a/statsig/spec_store.py
+++ b/statsig/spec_store.py
@@ -166,8 +166,8 @@ class _SpecStore:
             return False, False
         if specs_json.get("time", 0) < self.last_update_time():
             return False, False
-        copy = json.dumps(specs_json)
         if callable(self._options.rules_updated_callback):
+            copy = json.dumps(specs_json)
             self._options.rules_updated_callback(copy)
 
         def get_parsed_specs(key: str):


### PR DESCRIPTION
While doing some memory profiling on the python SDK, I realized that spec_store is making a copy of the downloaded spec data unnecessarily. This PR introduces an optimization that only performs a copy when rules_updated_callback is defined as an option

