### PR TITLE
Export exposed public attributes in main module

### DIFF
--- a/statsig/__init__.py
+++ b/statsig/__init__.py
@@ -15,3 +15,20 @@ from .statsig_server import StatsigServer
 from .statsig_user import StatsigUser
 from .utils import HashingAlgorithm
 from .version import __version__
+
+
+__all__ = [
+    "DynamicConfig",
+    "FeatureGate",
+    "HashingAlgorithm",
+    "IDataStore",
+    "Layer",
+    "LogLevel",
+    "OutputLogger",
+    "StatsigEnvironmentTier",
+    "StatsigEvent",
+    "StatsigOptions",
+    "StatsigServer",
+    "StatsigUser",
+    "__version__",
+]


### PR DESCRIPTION
Add public objects (only those not prefixed with `_`) to the main's
module `__init__.py` file, so that they're detected by automatic
linters.
