### PR TITLE
remove GRPC_VERBOSITY override

### DIFF
--- a/statsig/globals.py
+++ b/statsig/globals.py
@@ -1,5 +1,3 @@
-import os
-
 from .statsig_options import StatsigOptions
 from .statsig_telemetry_logger import StatsigTelemetryLogger
 
@@ -7,8 +5,6 @@ STATSIG_BATCHING_INTERVAL_SECONDS = 60.0
 STATSIG_LOGGING_INTERVAL_SECONDS = 1.0
 
 logger = StatsigTelemetryLogger()
-
-os.environ["GRPC_VERBOSITY"] = "NONE"
 
 
 def init_logger(options: StatsigOptions):


### PR DESCRIPTION
This override was preventing any code that imports statsig from using gRPC env based logging config.