### PR TITLE
Switch to casefold from upper lower

### DIFF
--- a/statsig/evaluator.py
+++ b/statsig/evaluator.py
@@ -576,18 +576,18 @@ class _Evaluator:
                 value, condition)
         if op == "str_starts_with_any":
             return self.__match_string_in_array(
-                value, target, lambda a, b: a.upper().lower().startswith(
-                    b.upper().lower()))
+                value, target, lambda a, b: a.casefold().startswith(
+                    b.casefold()))
         if op == "str_ends_with_any":
             return self.__match_string_in_array(
-                value, target, lambda a, b: a.upper().lower().endswith(
-                    b.upper().lower()))
+                value, target, lambda a, b: a.casefold().endswith(
+                    b.casefold()))
         if op == "str_contains_any":
             return self.__match_string_in_array(
-                value, target, lambda a, b: b.upper().lower() in a.upper().lower())
+                value, target, lambda a, b: b.casefold() in a.casefold())
         if op == "str_contains_none":
             return not self.__match_string_in_array(
-                value, target, lambda a, b: b.upper().lower() in a.upper().lower())
+                value, target, lambda a, b: b.casefold() in a.casefold())
         if op == "str_matches":
             str_value = self.__get_value_as_string(value)
             str_target = self.__get_value_as_string(target)
@@ -649,14 +649,14 @@ class _Evaluator:
         if (value is None or value == "") and user.custom is not None:
             if field in user.custom:
                 value = user.custom[field]
-            elif field.upper().lower() in user.custom:
-                value = user.custom[field.upper().lower()]
+            elif field.casefold() in user.custom:
+                value = user.custom[field.casefold()]
 
         if (value is None or value == "") and self._global_custom_fields is not None:
             if field in self._global_custom_fields:
                 value = self._global_custom_fields[field]
-            elif field.upper().lower() in self._global_custom_fields:
-                value = self._global_custom_fields[field.upper().lower()]
+            elif field.casefold() in self._global_custom_fields:
+                value = self._global_custom_fields[field.casefold()]
 
         if (value is None or value == "") and user.private_attributes is not None:
             if field in user.private_attributes:
@@ -722,7 +722,7 @@ class _Evaluator:
         if str_value is None or target is None:
             return False
         if op in ('any', 'none'):
-            return str_value.upper().lower() in target
+            return str_value.casefold() in target
         return str_value in target
 
     def __arrays_have_common_value(self, value, condition):

--- a/statsig/spec_store.py
+++ b/statsig/spec_store.py
@@ -416,7 +416,7 @@ class _SpecStore:
             rule["conditions"][condition_index]["fast_target_value"] = {}
             for val in target_value:
                 rule["conditions"][condition_index]["fast_target_value"][
-                    str(val).upper().lower()
+                    str(val).casefold()
                 ] = True
         elif op in (
                 "any_case_sensitive",


### PR DESCRIPTION
# Summary
Move from `.upper().lower()`  to `.casefold()` 

# Correctness 
first a bash script that shows correctness even with localized strings:
```
python - <<'PY' 
from hypothesis import find, strategies as st, settings, HealthCheck, Phase
import sys

# Alphabet: full Unicode (excl. surrogates), explicitly including tricky casings (e.g., ß/ẞ, Turkish İ/ı, ligatures)
alpha = st.characters(
    min_codepoint=0, max_codepoint=0x10FFFF,
    blacklist_categories=('Cs',),  # exclude surrogates
    whitelist_characters='ßẞİıſǆǅǄﬃﬁ'
)
text = st.text(alphabet=alpha)

try:
    with settings(max_examples=100000, deadline=None,
                  suppress_health_check=[HealthCheck.too_slow],
                  phases=(Phase.generate, Phase.shrink)):
        s = find(text, lambda x: x.upper().lower() != x.casefold())
    print("Found minimal counterexample:")
    print(f"s={s!r} (len={len(s)})")
    print(f"upper().lower() -> {s.upper().lower()!r}")
    print(f"casefold()      -> {s.casefold()!r}")
    sys.exit(1)
except Exception:
    print("No counterexample found for generated full-Unicode inputs (including 'weird' letters).")
PY
No counterexample found for generated full-Unicode inputs (including 'weird' letters).
```

# Benchmark 
Looks like a 2x speedup:
```
➜  python-sdk git:(wahba-perf-fix-casefold) python - <<'PY'
import timeit, random, sys

random.seed(0)

def gen_unicode(n):
    s = []
    while len(s) < n:
        cp = random.randint(0, 0x10FFFF)
        if 0xD800 <= cp <= 0xDFFF:
            continue
        try:
            s.append(chr(cp))
        except ValueError:
            pass
    return ''.join(s)

# Mixed dataset: ASCII, tricky Unicode (e.g., ß/İ/ı/ﬃ), and random Unicode
DATA = [
    "Straße", "weißße", "İstanbul", "ıiIİ", "naïve", "ﬃ ffi",
    "Γειά σου", "Добрый день", "中文測試", "日本語テスト",
]
for L in (8, 32, 128, 1024):
    DATA.append(''.join(random.choice("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") for _ in range(L)))
for L in (8, 32, 128, 1024):
    DATA.append(gen_unicode(L))

def bench(stmt, number=500):
    return timeit.timeit(stmt, number=number, globals=globals())

N = 1000
t_ul = bench("for s in DATA: s.upper().lower()", N)
t_cf = bench("for s in DATA: s.casefold()", N)

iters = N * len(DATA)
def fmt(t): return f"{iters/t:,.0f} ops/sec ({t:.3f}s)"

print(f"upper().lower(): {fmt(t_ul)}")
print(f"casefold():      {fmt(t_cf)}")
speedup = t_ul / t_cf if t_cf > 0 else float('inf')
print(f"Speedup (casefold vs upper().lower()): {speedup:.2f}x (>{1.0} means casefold faster)")
PY
upper().lower(): 2,732,828 ops/sec (0.007s)
casefold():      3,625,895 ops/sec (0.005s)
Speedup (casefold vs upper().lower()): 1.33x (>1.0 means casefold faster)
```