### PR TITLE
fix: re-export `statsig` submodule and complete `__all__`

### DIFF
--- a/statsig/__init__.py
+++ b/statsig/__init__.py
@@ -1,3 +1,4 @@
+from . import statsig as statsig
 from .dynamic_config import DynamicConfig
 from .evaluator import _Evaluator
 from .feature_gate import FeatureGate
@@ -25,10 +26,12 @@ __all__ = [
     "Layer",
     "LogLevel",
     "OutputLogger",
+    "statsig",
     "StatsigEnvironmentTier",
     "StatsigEvent",
     "StatsigOptions",
     "StatsigServer",
     "StatsigUser",
+    "StreamDecompressor",
     "__version__",
 ]


### PR DESCRIPTION
The `statsig` package marks itself as typed (`py.typed`) but doesn't properly re-export its public API from `__init__.py`. Strict type checkers like [ty](https://github.com/astral-sh/ty) report `unresolved-import` for `from statsig import statsig` because the submodule is never imported in `__init__.py`'s namespace.

## Changes

- Add `from . import statsig as statsig` to explicitly re-export the `statsig` submodule (the `as statsig` form signals an intentional re-export per [PEP 484](https://peps.python.org/pep-0484/#stub-files))
- Add `"statsig"` and `"StreamDecompressor"` to `__all__` (`StreamDecompressor` was already imported but missing from the list)
